### PR TITLE
chore: Set Git identity

### DIFF
--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -23,6 +23,9 @@ jobs:
           else
             npm install
           fi
+      - run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
       - run: npx shipjs trigger
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix failure of release workflow.

```$ git tag -a v0.3.3 -m v0.3.3
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az337-844.jbyrdabdzgkepcqk1sdi5hhfzg.jx.internal.cloudapp.net>) not allowed
```

https://github.com/nandenjin/mrm-preset/actions/runs/4081650788/jobs/7035230865