### PR TITLE
fix: Consider the case of `eslintrc.extends` is type of string

### DIFF
--- a/prettier/index.js
+++ b/prettier/index.js
@@ -20,7 +20,8 @@ module.exports = () => {
       'prettier: .eslintrc.json detected. Adding eslint-prettier-config'
     )
     const eslintrc = json('.eslintrc.json')
-    eslintrc.set('extends', [...eslintrc.get('extends'), 'prettier']).save()
+    const prevExtends = eslintrc.get('extends')
+    eslintrc.set('extends', [...(Array.isArray(prevExtends) ? prevExtends : [prevExtends]), 'prettier']).save()
     deps.push('eslint-config-prettier')
   }
 


### PR DESCRIPTION
Fixes #24